### PR TITLE
fix to comply with redmine 5.0.x

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require_dependency 'sidebar_hook_listener'
+require File.expand_path('lib/sidebar_hook_listener', __dir__)
 
 Redmine::Plugin.register :redmine_hide_sidebar do
   name 'Sidebar Hide Plugin'


### PR DESCRIPTION
This should fix issue #4 for Redmine 5.0.1. Tested with official Redmine Docker container at version 5.0.1.
However, not testet against older redmine releases for backward compatibility.